### PR TITLE
Disable the add new button when editing Archive Page post

### DIFF
--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -31,6 +31,10 @@ function hdptap_register_cpt_archive_post_type() {
 			'menu_icon'             => 'dashicons-media-text',
 			'query_var'             => 'hdptap_cpt_archive',
 			'menu_position'         => 26,
+			'map_meta_cap'          => true, // Set to `false`, if users are not allowed to edit/delete existing posts.
+			'capabilities'          => array(
+				'create_posts' => false, // Removes support for the "Add New" function ( use 'do_not_allow' instead of false for multisite set ups ).
+			),
 
 			'labels'                => array(
 				'name'                  => _x( 'Archive Pages', 'post type general name', 'post-type-archive-pages' ),


### PR DESCRIPTION
Remove the "Add New" button which appears next to the title in the Edit Archive Page title. Button is redundant because the post archive page has already been added.