### PR TITLE
Fix paramater type for registered_post_type action

### DIFF
--- a/post-type-archive-pages.php
+++ b/post-type-archive-pages.php
@@ -108,8 +108,10 @@ require_once( dirname( __FILE__ ) . '/inc/filters.php' );
  * Creates the archives pages for the post types that are set to use an archive.
  * If the pages already exist it does nothing for that post type.
  *
- * @param  string $post_type The name of the post type registered.
- * @param  array  $args       An array of registered post type arguments.
+ * @param string       $post_type The name of the post type registered.
+ * @param WP_Post_Type $args      Arguments used to register the post type.
+ *
+ * @return mixed
  */
 function hdptap_create_archive_pages( $post_type, $args ) {
 


### PR DESCRIPTION
The second parameter of the `registered_post_type` action is an object but the function doc refers to an array. This fixes an error in my PHPCS.